### PR TITLE
Now can also use ark id

### DIFF
--- a/www/src/components/istex-api-doc-button.jsx
+++ b/www/src/components/istex-api-doc-button.jsx
@@ -8,7 +8,7 @@ class IstexApiDocButton extends React.Component {
     this.state = {
       atitle: '',
       genre: '',
-      istexId: '',
+      arkId: '',
       abstractNbLineView: 2,
     };
   }
@@ -19,7 +19,7 @@ class IstexApiDocButton extends React.Component {
     self.setState({
       atitle: self.props.doc.title,
       genre: self.props.doc.genre[0],
-      istexId: self.props.doc.id
+      arkId: self.props.doc.ark
     });
   }
 
@@ -27,9 +27,9 @@ class IstexApiDocButton extends React.Component {
     let self = this;
 
     return (
-      <a href={'/' + self.state.istexId}  className="btn btn-default btn-lg iv-doc-button" role="button" key={self.state.istexId} title={self.state.atitle}>
+      <a href={'/' + self.state.arkId}  className="btn btn-default btn-lg iv-doc-button" role="button" key={self.state.arkId} title={self.state.atitle}>
         <div className="iv-istex-icon" data-article-type={self.state.genre} title={self.state.genre}></div>
-        <span className="iv-istexid">{self.state.istexId}</span>
+        <span className="iv-arkId">{self.state.arkId}</span>
       </a>
     );
   }

--- a/www/src/components/istex-api-doc-record.jsx
+++ b/www/src/components/istex-api-doc-record.jsx
@@ -18,7 +18,7 @@ class IstexApiDocRecord extends React.Component {
 
     let theUrl = self.props.config.istexApiProtocol + '://' + self.props.config.istexApiDomain;
 
-    if (this.state.istexId.startsWith('ark:/')) {
+    if (this.state.istexId.startsWith('ark:/67375/')) {
       theUrl += '/' + self.props.istexId + '/?sid=istex-view';
     }
 

--- a/www/src/components/istex-api-doc-record.jsx
+++ b/www/src/components/istex-api-doc-record.jsx
@@ -17,7 +17,15 @@ class IstexApiDocRecord extends React.Component {
     if (!self.props.config.istexApiProtocol || !self.props.config.istexApiDomain) return;
 
     let theUrl = self.props.config.istexApiProtocol + '://' + self.props.config.istexApiDomain;
-    theUrl += '/document/' + self.props.istexId + '/?sid=istex-view';
+
+    if (this.state.istexId.startsWith('ark:/')) {
+      theUrl += '/' + self.props.istexId + '/?sid=istex-view';
+    }
+
+    else {
+      theUrl += '/document/' + self.props.istexId + '/?sid=istex-view';
+    }
+    
     $.get(theUrl).done(function (docRecord) {
       self.setState({
         loaded: true,

--- a/www/src/components/view-doc.jsx
+++ b/www/src/components/view-doc.jsx
@@ -11,7 +11,7 @@ class ViewDoc extends React.Component {
     this.state = {
       currentPage: 1,
       pages: 0,
-      istexId: '',
+      istexId: '', // Can be IstexId (40 caracters) or ArkId (ex. ark:/67375/0T8-542WXJ63-8)
       istexToken: jwtToken 
     };
   }
@@ -45,9 +45,16 @@ class ViewDoc extends React.Component {
 
   render() {
     let self = this;
+    var pdfUrl;
 
-    var pdfUrl = self.state.istexId ? self.props.config.istexApiUrl + '/document/' + this.state.istexId + '/fulltext/pdf?sid=istex-view' : '';
+    if (this.state.istexId.startsWith('ark:/')) {
+      pdfUrl = self.state.istexId ? self.props.config.istexApiUrl + '/' + this.state.istexId + '/fulltext.pdf?sid=istex-view' : '';
+    }
 
+    else {
+      pdfUrl = self.state.istexId ? self.props.config.istexApiUrl + '/document/' + this.state.istexId + '/fulltext/pdf?sid=istex-view' : '';
+    }
+    
     var ReactPdf2 = pdfUrl ? (
       <PDF src={pdfUrl} jwtToken={this.state.istexToken}>
         <PDFViewer />

--- a/www/src/components/view-openurl.jsx
+++ b/www/src/components/view-openurl.jsx
@@ -133,7 +133,17 @@ class ViewOpenUrl extends React.Component {
   mapApiUrlToViewUrl(apiUrl) {
     let self = this;
 
-    var matches = apiUrl && apiUrl.match(new RegExp('api\.istex\.fr\/document\/([A-Z0-9]{40})\/'));
+    var matches;
+
+    if (apiUrl.includes('/document/')) {
+      matches = apiUrl && apiUrl.match(new RegExp('api\.istex\.fr\/document\/([A-Z0-9]{40})\/'));
+    }
+
+    if (apiUrl.includes('/ark:/')) {
+      matches = apiUrl && apiUrl.match(new RegExp('api\.istex\.fr\/(ark:\/[0-9]{5}\/[A-Z0-9]{3}-[A-Z0-9]{8}-[A-Z0-9])\/'));
+    }
+    
+
     if (matches) {
       if (self.props.config.openUrlFTRedirectTo == 'api-with-ezproxy-auth') {
         // When view.istex.fr is access behind the an ezproxy, 

--- a/www/src/components/view-openurl.jsx
+++ b/www/src/components/view-openurl.jsx
@@ -139,8 +139,8 @@ class ViewOpenUrl extends React.Component {
       matches = apiUrl && apiUrl.match(new RegExp('api\.istex\.fr\/document\/([A-Z0-9]{40})\/'));
     }
 
-    if (apiUrl.includes('/ark:/')) {
-      matches = apiUrl && apiUrl.match(new RegExp('api\.istex\.fr\/(ark:\/[0-9]{5}\/[A-Z0-9]{3}-[A-Z0-9]{8}-[A-Z0-9])\/'));
+    if (apiUrl.includes('/ark:/67375/')) {
+      matches = apiUrl && apiUrl.match(new RegExp('api\.istex\.fr\/(ark:/67375\/[A-Z0-9]{3}-[A-Z0-9]{8}-[A-Z0-9])\/'));
     }
     
 

--- a/www/src/main.jsx
+++ b/www/src/main.jsx
@@ -28,7 +28,7 @@ function render() {
         <Route path="/openurl*"
                component={(props) => (<ViewOpenUrl config={ivConfigModel.data} location={props.location} />)} />
 
-        <Route path="/(ark:/[0-9]{5}/[A-Z0-9]{3}-[A-Z0-9]{8}-[A-Z0-9])"
+        <Route path="/(ark:/67375/[A-Z0-9]{3}-[A-Z0-9]{8}-[A-Z0-9])"
                component={(props) => (<ViewDoc config={ivConfigModel.data} location={props.location} match={props.match} />)} />
         <Route path="/([0-9A-Z]{40})"
                component={(props) => (<ViewDoc config={ivConfigModel.data} location={props.location} match={props.match} />)} />

--- a/www/src/main.jsx
+++ b/www/src/main.jsx
@@ -28,6 +28,8 @@ function render() {
         <Route path="/openurl*"
                component={(props) => (<ViewOpenUrl config={ivConfigModel.data} location={props.location} />)} />
 
+        <Route path="/(ark:/[0-9]{5}/[A-Z0-9]{3}-[A-Z0-9]{8}-[A-Z0-9])"
+               component={(props) => (<ViewDoc config={ivConfigModel.data} location={props.location} match={props.match} />)} />
         <Route path="/([0-9A-Z]{40})"
                component={(props) => (<ViewDoc config={ivConfigModel.data} location={props.location} match={props.match} />)} />
         <Route path="/document/([0-9A-Z]{40})"


### PR DESCRIPTION
- Can now support url with id ark from istex API
- Show buttons with id ark on main page (https://view.istex.fr/)
- Add Route to support url with ark id (eg : https://view.istex.fr/ark:/67375/0T8-542WXJ63-8)
- Can still support url with id Istex from istex API (just in case)